### PR TITLE
Migrated to new type identification method

### DIFF
--- a/src/isPxth.ts
+++ b/src/isPxth.ts
@@ -1,5 +1,5 @@
 import { SegmentsToken } from './getPxthSegments';
 import { Pxth } from './Pxth';
 
-export const isPxth = (path: unknown): path is Pxth<unknown> =>
+export const isPxth = <T>(path: unknown): path is Pxth<T> =>
     typeof path === 'object' && path !== null && SegmentsToken in path;


### PR DESCRIPTION
We have migrated to a more stable and correct type identification method.

Now, the following cases will work:
```ts
type A = { 
    field: number;
};

type B = {
    field: number;
    additionalField: string;
};

const a: Pxth<A> = /* some initialization */;
const b: Pxth<B> = /* some initialization */;

// This will work because type B is more comprehensive than type A. Wasn't working previously.
const c: Pxth<A> = b;

// This will not work, type A does not satisfy type B constraints.
const d: Pxth<B> = a;
```